### PR TITLE
chore: :speech_balloon: add main readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Monorepo Overview
+
+``` plaintext
+┌───────────────┐                          ┌───────────────┐
+│    Client     │                          │    Server     │
+│ ┌───────────┐ │                          │ ┌───────────┐ │
+│ │   Socket  │─┼──── Connection ──────────┼▶│   Socket  │ │
+│ └───────────┘ │                          │ └───────────┘ │
+└───────────────┘                          └───────────────┘
+      │                                            │
+      │─ Request (send data) ─────────────────────▶│
+      │                                            │
+      │◀─ Response (receive data) ─────────────────│
+      │                                            │
+      │─ Close Connection ────────────────────────▶│
+      │                                            │
+      │◀─ Acknowledge Close ───────────────────────│
+```
+
+This repository contains four distinct projects organized in a workspace:
+
+``` plaintext
+.
+├── client/            # Static single-page application (HTML, CSS, JS)
+├── js/                # Plain JavaScript WebSocket server (CommonJS)
+├── nestjs/            # NestJS WebSocket gateway application (TypeScript)
+└── ts/                # TypeScript WebSocket server
+LICENSE                # Repository license
+```
+
+## Projects
+
+### 1. `client/`
+
+A front-end single-page application that connects to WebSocket servers using client-side JavaScript.
+
+* **Entry point:** `client/index.html`
+* **Static assets:** `client/public/assets/`
+* **Source code:** `client/src/index.js`
+* **Client behavior:** Opens a WebSocket connection, handles incoming messages, and allows sending messages via a simple UI.
+
+### 2. `js/`
+
+A minimal WebSocket server implemented in CommonJS JavaScript using Socket.IO on top of Node's HTTP module.
+
+* **Server file:** `js/src/index.js`
+* **Functionality:** Accepts client connections, broadcasts connect/disconnect events and relays chat messages to all clients.
+
+### 3. `nestjs/`
+
+A full-featured NestJS application providing a Socket.IO gateway for real-time updates.
+
+* **Gateway implementation:** `nestjs/src/app/socket/infrastructure/gateways/chat.gateway.ts`
+* **Module:** `nestjs/src/app/socket/socket.module.ts`
+* **Bootstrap:** `nestjs/src/main.ts`, `nestjs/src/app.module.ts`
+* **Testing:** located under `nestjs/test/`
+* **Configuration:** ESLint, Nest CLI, TypeScript configs under the project root.
+
+### 4. `ts/`
+
+A TypeScript-based WebSocket server using Socket.IO and Node's HTTP module.
+
+* **Source:** `ts/src/index.ts`
+* **Build config:** `ts/tsconfig.json`
+* **Behavior:** Similar to the JS server but written in TypeScript for type safety.
+
+## Workspace Tooling
+
+* Uses **pnpm** workspaces (each subfolder contains its own lockfile).
+* You can run scripts scoped to each project via your package manager (e.g., `pnpm --filter client run start`).
+
+## License
+
+This repository is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
This pull request updates the `README.md` file to provide a comprehensive overview of the monorepo structure and its projects. The changes aim to improve documentation clarity and make it easier for developers to understand the repository's organization and functionality.

### Documentation Improvements:
* Added a high-level architectural diagram illustrating the interaction between the client and server via WebSocket connections.
* Introduced an overview of the repository structure, detailing the four distinct projects (`client/`, `js/`, `nestjs/`, and `ts/`) and their purposes.
* Provided detailed descriptions for each project, including entry points, key files, functionality, and configuration details.
* Documented workspace tooling, highlighting the use of `pnpm` workspaces and how to run project-specific scripts.
* Included a section on the repository's licensing under the MIT License.